### PR TITLE
Para que el supervisor no pueda Agregar componentes

### DIFF
--- a/viixoo_app_engine/viixoo_frontend_apps/src/components/WorkOrders/AddComponentsWorkOrders.tsx
+++ b/viixoo_app_engine/viixoo_frontend_apps/src/components/WorkOrders/AddComponentsWorkOrders.tsx
@@ -109,7 +109,7 @@ export const AddComponentsWorkOrders = ({ item }: WorkOrderProps) => {
     >
       <DialogTrigger asChild>
         <Button my={2} maxH="35px" width="100%" variant="subtle" size="md" colorPalette="gray" display={
-                 !["supervisor", "warehouse"].includes(item.access_type)? 'none' : 'flex'
+                 !["warehouse"].includes(item.access_type)? 'none' : 'flex'
                 }>
           Agregar componente
         </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “Agregar componente” button in work orders is now visible only to users with warehouse access, and hidden for supervisors and all other roles.
  - Ensures the interface reflects appropriate permissions, reducing confusion and preventing unintended actions by non-authorized users.
  - No other user-facing behavior is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->